### PR TITLE
Set default namespace in atoum\phpMocker

### DIFF
--- a/Unit/Suite.php
+++ b/Unit/Suite.php
@@ -73,4 +73,22 @@ class Suite extends atoum\test {
 
         return '\\';
     }
+
+    public function beforeTestMethod ( $methodName ) {
+
+        $out             = parent::beforeTestMethod($methodName);
+        $testedClassName = self::getTestedClassNameFromTestClass(
+            $this->getClass(),
+            $this->getTestNamespace()
+        );
+        $testedNamespace = substr(
+            $testedClassName,
+            0,
+            strrpos($testedClassName, '\\')
+        );
+
+        $this->getPhpMocker()->setDefaultNamespace($testedNamespace);
+
+        return $out;
+    }
 }


### PR DESCRIPTION
Since we unlink a test suite name from a SUT name, the [`atoum\phpMocker` class](https://github.com/atoum/atoum/blob/a9503a7a0c5b1f5893f9ec01c35082dc4a6c4cd3/classes/php/mocker.php) has no default namespace and is not able to work properly. This patch fix this.

In other words, it restores the `$this->function->…` function mocking system :-).
