### PR TITLE
Auto-substream

### DIFF
--- a/Protocol/Vfs.php
+++ b/Protocol/Vfs.php
@@ -56,7 +56,14 @@ class Vfs extends Core\Protocol {
      *
      * @var \Hoa\Core\Protocol string
      */
-    protected $_name = 'Vfs';
+    protected $_name    = 'Vfs';
+
+    /**
+     * Current opened streams.
+     *
+     * @var \Hoa\Test\Protocol\Vfs array
+     */
+    protected $_streams = [];
 
 
 
@@ -90,6 +97,11 @@ class Vfs extends Core\Protocol {
         else
             $file = atoum\mock\streams\fs\file::get($path);
 
+        $parentDirectory = dirname($path);
+
+        if(isset($this->_streams[$parentDirectory]))
+            $this->_streams[$parentDirectory]->dir_readdir[] = $file;
+
         foreach($queries as $query => $value)
             switch($query) {
 
@@ -104,6 +116,8 @@ class Vfs extends Core\Protocol {
                     $file->setPermissions($value);
                   break;
             }
+
+        $this->_streams[$path] = $file;
 
         return (string) $file;
     }


### PR DESCRIPTION
Detect if a stream has a parent, and if yes, automatically create a substream.

Example:

```
    to create
        Root/
            A
            Aa
            Aaa
            B/
                Foo
                Bar

    all we have to do is to resolve the following paths:
        hoa://Test/Vfs/Root?type=directory
        hoa://Test/Vfs/Root/A
        hoa://Test/Vfs/Root/Aa
        hoa://Test/Vfs/Root/Aaa
        hoa://Test/Vfs/Root/B?type=directory
        hoa://Test/Vfs/Root/B/Foo
        hoa://Test/Vfs/Root/B/Bar
```
