### PR TITLE
Install hoa/dispatcher & hoa/router to use `hoa`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "hywan/atoum"            : "~1.0",
         "atoum/praspel-extension": "~0.0",
         "hoa/console"            : "~2.0",
         "hoa/core"               : "~2.0",
-        "hoa/file"               : "~0.0"
+        "hoa/dispatcher"         : "~0.0",
+        "hoa/file"               : "~0.0",
+        "hoa/router"             : "~2.0",
+        "hywan/atoum"            : "~1.0"
     },
     "target-dir": "Hoa/Test",
     "autoload"  : { "psr-0": { "Hoa\\Test": "." } },


### PR DESCRIPTION
Why not in `require-dev` of `Hoa\Core`? Because `require-dev` are not recursives. And need `Hoa\Dispatcher` and `Hoa\Router` to use `hoa` in CLI.
