### PR TITLE
Fix ruler-extension namespace.

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -3,4 +3,4 @@
 require_once __DIR__ . DIRECTORY_SEPARATOR . '.autoload.atoum.php';
 
 $runner->addExtension(new Atoum\PraspelExtension\Manifest());
-$runner->addExtension(new atoum\ruler\extension($script));
+$runner->addExtension(new mageekguy\atoum\ruler\extension($script));


### PR DESCRIPTION
When I would like to run tests for my PR on Hoa\Database I got this error: Fatal error: Class 'atoum\ruler\extension' not found...

How to reproduce:
* `git clone` a Hoa library(eg: [Hoa\Database](https://github.com/hoaproject/Database.git)),
* `composer install`,
* `vendor/bin/hoa test:run -d Test`.

The error is throw in [.atoum.php](https://github.com/hoaproject/Test/blob/e8fef0aff5/.atoum.php#L6) when resolving `atoum\ruler\extension` to `\mageekguy\atoum\ruler\extension`.
So I added the first namespace part and it's work.

Moreover in [atoum/ruler-extension's README](https://github.com/atoum/ruler-extension/blob/master/README.md) the FQCN is used:
> `$runner->addExtension(new \mageekguy\atoum\ruler\extension($script));`

May be I miss some things ? How do you run your tests?
____
An other way to fix the error is to include `vendor/atoum/ruler-extension/autoloader.php` in `Hoa/Test/.autoload.atoum.php`. (related to https://github.com/atoum/ruler-extension/pull/17)