### PR TITLE
Require `hoa/devtools`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "atoum/ruler-extension"  : "~1.0, >=1.0.2",
         "hoa/cli"                : "~1.0",
         "hoa/core"               : "~2.0",
+        "hoa/devtools"           : "~0.0",
         "hoa/file"               : "~0.0",
         "hoa/ustring"            : "~3.0"
     },


### PR DESCRIPTION
It makes sense to require `hoa/devtools` because it contains tools like `devtools:cs`. This latter is very often used along with `test:run`.