### PR TITLE
Force `atoum` to run in a specific CWD

### DIFF
--- a/.autoload.atoum.php
+++ b/.autoload.atoum.php
@@ -1,5 +1,7 @@
 <?php
 
+date_default_timezone_set('Europe/Paris');
+
 $composer =
     dirname(__DIR__) . DIRECTORY_SEPARATOR .
     '..' . DIRECTORY_SEPARATOR .

--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,5 +1,9 @@
 <?php
 
+if (isset($_SERVER['HOA_PREVIOUS_CWD'])) {
+    chdir($_SERVER['HOA_PREVIOUS_CWD']);
+}
+
 require_once __DIR__ . DIRECTORY_SEPARATOR . '.autoload.atoum.php';
 
 Hoa\Core::enableErrorHandler();

--- a/Bin/Run.php
+++ b/Bin/Run.php
@@ -290,7 +290,17 @@ class Run extends Console\Dispatcher\Kit
             $command .= ' --filter \'' . str_replace('\'', '\'"\'"\'', $filter) . '\'';
         }
 
-        $processus = new Processus($command);
+
+        $_server                     = $_SERVER;
+        $_server['HOA_PREVIOUS_CWD'] = getcwd();
+
+        $processus = new Processus(
+            $command,
+            null,
+            null,
+            resolve('hoa://Library/Test/'),
+            $_server
+        );
         $processus->on('input', function ($bucket) {
             return false;
         });


### PR DESCRIPTION
The current working directory (CWD) of atoum was not very well defined.
Now we force it to `hoa://Library/Test/`. In this case, it is able to
find a default `.bootstrap.atoum.php` file, and then it can load it to
find command-line arguments to add (useful for the
`atoum/ruler-extension` extension). We set a `HOA_PREVIOUS_CWD`
environment variable to reset the CWD before executing the tests. Why?
Because, for instance, if we execute:

    $ vendor/bin/hoa test:run --directories Test/

With CWD set to `hoa://Library/Test/`, the `Test/` directory will not
exist, because it will look for `hoa://Library/Test/Test`. By resetting
the CWD, we fix this problem (back to normal).