### PR TITLE
Documentation: Fix schema loading error

### DIFF
--- a/Documentation/En/Index.xyl
+++ b/Documentation/En/Index.xyl
@@ -69,7 +69,7 @@
   <figure>
     <object
       type="image/svg+xml"
-      data="http://central.hoa-project.net/Resource/Library/Test/Documentation/Image/Cartography.svg?format=raw"
+      data="http://central.hoa-project.net/Resource/Library/Test/Documentation/Image/Cartography.svg?format=raw&amp;remote=hoa"
       width="100%" style="max-width: 870px"></object>
     <figcaption>Dimensions of the test universe is represented by
     3 axis.</figcaption>


### PR DESCRIPTION
By default, if no remote or referrer is present for a
central.hoa-project.net resource, we will fallback to Github.
Unfortunately, Github adds a `X-Frame-Options: deny` header
([X-Frame-Options], [RFC7034]). So we force the remote to `hoa` to solve
this problem since `git.hoa-project.net` does not add this header. Also,
we can trust our own services ;-).

[X-Frame-Options]: https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options
[RFC7034]: http://tools.ietf.org/html/rfc7034