### PR TITLE
Add custom atoum report

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -5,3 +5,5 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . '.autoload.atoum.php';
 $runner->addExtension(new Atoum\PraspelExtension\Manifest());
 $runner->addExtension(new mageekguy\atoum\ruler\extension($script));
 $runner->addExtension(new mageekguy\atoum\visibility\extension($script));
+$report = new Hoa\Test\Report\Cli\Cli();
+$runner->addReport($report->addWriter(new atoum\writers\std\out()));

--- a/Documentation/En/Index.xyl
+++ b/Documentation/En/Index.xyl
@@ -476,7 +476,7 @@ class Bar extends Test\Unit\Suite
   <p>The CLI test reporter will use colours to indicate the <strong>test
   verdict</strong>: green for success, red for fail or inconclusive. In case
   of a success, we should see:</p>
-  <pre><code>Success (<em>S</em> tests, <em>c</em>/<em>C</em> methods, <em>V</em> void method, <em>K</em> skipped method, <em>A</em> assertions)!</code></pre>
+  <pre><code>Success (<em>S</em> test suites, <em>c</em>/<em>C</em> test cases, <em>V</em> void test cases, <em>K</em> skipped test cases, <em>A</em> assertions)!</code></pre>
   <p>where:</p>
   <ul>
     <li><code><em>S</em></code> is the number of test suites,</li>
@@ -487,7 +487,7 @@ class Bar extends Test\Unit\Suite
     <li><code><em>A</em></code> is the numbre of assertions.</li>
   </ul>
   <p>In case of a failure, we should see:</p>
-  <pre><code>Failure (<em>S</em> tests, <em>c</em>/<em>C</em> methods, <em>V</em> void method, <em>K</em> skipped method, …, <em>F</em> failure, <em>E</em> error, <em>X</em> exception)!
+  <pre><code>Failure (<em>S</em> test suites, <em>c</em>/<em>C</em> test cases, <em>V</em> void test cases, <em>K</em> skipped test cases, …, <em>F</em> failure, <em>E</em> error, <em>X</em> exception)!
 > There is <em>F</em> failure:
 …</code></pre>
   <ul>

--- a/Report/Cli/Cli.php
+++ b/Report/Cli/Cli.php
@@ -57,6 +57,22 @@ class Cli extends atoum\reports\realtime
         $secondLevelPrompt = new atoum\cli\prompt('=> ', $defaultPromptColorizer);
         $thirdLevelPrompt  = new atoum\cli\prompt('==> ', $defaultPromptColorizer);
 
+        $atoumPathField = new runner\atoum\path\cli();
+        $atoumPathField
+            ->setPrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($atoumPathField);
+
+        $atoumVersionField = new runner\atoum\version\cli();
+        $atoumVersionField
+            ->setTitlePrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($atoumVersionField);
+
         $phpPathField = new runner\php\path\cli();
         $phpPathField
             ->setPrompt($firstLevelPrompt)

--- a/Report/Cli/Cli.php
+++ b/Report/Cli/Cli.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli;
+
+use atoum;
+use atoum\report\fields\runner;
+use atoum\report\fields\test;
+
+class Cli extends atoum\reports\realtime
+{
+    private $runnerTestsCoverageField;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->addField(new Fields\Logo());
+
+        $defaultColorizer = new atoum\cli\colorizer(Colors::FG . Colors::WHITE);
+        $defaultPromptColorizer = new atoum\cli\colorizer(Colors::FG . Colors::RED);
+
+        $firstLevelPrompt  = new atoum\cli\prompt('> ', $defaultPromptColorizer);
+        $secondLevelPrompt = new atoum\cli\prompt('=> ', $defaultPromptColorizer);
+        $thirdLevelPrompt  = new atoum\cli\prompt('==> ', $defaultPromptColorizer);
+
+        $phpPathField = new runner\php\path\cli();
+        $phpPathField
+            ->setPrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($phpPathField);
+
+        $phpVersionField = new runner\php\version\cli();
+        $phpVersionField
+            ->setTitlePrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+            ->setVersionPrompt($secondLevelPrompt)
+        ;
+
+        $this->addField($phpVersionField);
+
+        $runnerTestsDurationField = new runner\tests\duration\cli();
+        $runnerTestsDurationField
+            ->setPrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($runnerTestsDurationField);
+
+        $runnerTestsMemoryField = new runner\tests\memory\cli();
+        $runnerTestsMemoryField
+            ->setPrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($runnerTestsMemoryField);
+
+        $this->runnerTestsCoverageField = new runner\tests\coverage\cli();
+        $this->runnerTestsCoverageField
+            ->setTitlePrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+            ->setClassPrompt($secondLevelPrompt)
+            ->setMethodPrompt(new atoum\cli\prompt('==> ', $defaultColorizer))
+        ;
+
+        $this->addField($this->runnerTestsCoverageField);
+
+        $runnerDurationField = new runner\duration\cli();
+        $runnerDurationField
+            ->setPrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+        ;
+
+        $this->addField($runnerDurationField);
+
+        $runnerResultField = new Fields\Result();
+        $runnerResultField
+            ->setSuccessColorizer(new atoum\cli\colorizer(Colors::BG . Colors::GREEN, Colors::FG . Colors::BLACK . Colors::BOLD))
+            ->setFailureColorizer(new atoum\cli\colorizer(Colors::BG . Colors::RED, Colors::FG . Colors::BLACK . Colors::BOLD))
+        ;
+
+        $this->addField($runnerResultField);
+
+        $failureColorizer = new atoum\cli\colorizer(Colors::FG . Colors::RED . Colors::BOLD);
+        $failureTitlePrompt = clone $firstLevelPrompt;
+        $failureTitlePrompt->setColorizer($failureColorizer);
+        $failurePrompt = clone $secondLevelPrompt;
+        $failurePrompt->setColorizer($failureColorizer);
+
+        $runnerFailuresField = new runner\failures\cli();
+        $runnerFailuresField
+            ->setTitlePrompt($failureTitlePrompt)
+            ->setTitleColorizer($failureColorizer)
+            ->setMethodPrompt($failurePrompt)
+        ;
+
+        $this->addField($runnerFailuresField);
+
+        $runnerOutputsField = new runner\outputs\cli();
+        $runnerOutputsField
+            ->setTitlePrompt($firstLevelPrompt)
+            ->setTitleColorizer($defaultColorizer)
+            ->setMethodPrompt($secondLevelPrompt)
+        ;
+
+        $this->addField($runnerOutputsField);
+
+        $errorColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::YELLOW . Colors::BOLD);
+        $errorTitlePrompt = clone $firstLevelPrompt;
+        $errorTitlePrompt->setColorizer($errorColorizer);
+        $errorMethodPrompt = clone $secondLevelPrompt;
+        $errorMethodPrompt->setColorizer($errorColorizer);
+        $errorPrompt = clone $thirdLevelPrompt;
+        $errorPrompt->setColorizer($errorColorizer);
+
+        $runnerErrorsField = new runner\errors\cli();
+        $runnerErrorsField
+            ->setTitlePrompt($errorTitlePrompt)
+            ->setTitleColorizer($errorColorizer)
+            ->setMethodPrompt($errorMethodPrompt)
+            ->setErrorPrompt($errorPrompt)
+        ;
+
+        $this->addField($runnerErrorsField);
+
+        $exceptionColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::VIOLET . Colors::BOLD);
+        $exceptionTitlePrompt = clone $firstLevelPrompt;
+        $exceptionTitlePrompt->setColorizer($exceptionColorizer);
+        $exceptionMethodPrompt = clone $secondLevelPrompt;
+        $exceptionMethodPrompt->setColorizer($exceptionColorizer);
+        $exceptionPrompt = clone $thirdLevelPrompt;
+        $exceptionPrompt->setColorizer($exceptionColorizer);
+
+        $runnerExceptionsField = new runner\exceptions\cli();
+        $runnerExceptionsField
+            ->setTitlePrompt($exceptionTitlePrompt)
+            ->setTitleColorizer($exceptionColorizer)
+            ->setMethodPrompt($exceptionMethodPrompt)
+            ->setExceptionPrompt($exceptionPrompt)
+        ;
+
+        $this->addField($runnerExceptionsField);
+
+        $uncompletedTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::WHITE . Colors::BOLD);
+        $uncompletedTestTitlePrompt = clone $firstLevelPrompt;
+        $uncompletedTestTitlePrompt->setColorizer($uncompletedTestColorizer);
+        $uncompletedTestMethodPrompt = clone $secondLevelPrompt;
+        $uncompletedTestMethodPrompt->setColorizer($uncompletedTestColorizer);
+        $uncompletedTestOutputPrompt = clone $thirdLevelPrompt;
+        $uncompletedTestOutputPrompt->setColorizer($uncompletedTestColorizer);
+
+        $runnerUncompletedField = new Fields\Uncompleted();
+        $runnerUncompletedField
+            ->setTitlePrompt($uncompletedTestTitlePrompt)
+            ->setTitleColorizer($uncompletedTestColorizer)
+            ->setMethodPrompt($uncompletedTestMethodPrompt)
+            ->setOutputPrompt($uncompletedTestOutputPrompt)
+        ;
+
+        $this->addField($runnerUncompletedField);
+
+        $voidTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::BLUE . Colors::BOLD);
+        $voidTestTitlePrompt = clone $firstLevelPrompt;
+        $voidTestTitlePrompt->setColorizer($voidTestColorizer);
+        $voidTestMethodPrompt = clone $secondLevelPrompt;
+        $voidTestMethodPrompt->setColorizer($voidTestColorizer);
+
+        $runnerVoidField = new Fields\Void();
+        $runnerVoidField
+            ->setTitlePrompt($voidTestTitlePrompt)
+            ->setTitleColorizer($voidTestColorizer)
+            ->setMethodPrompt($voidTestMethodPrompt)
+        ;
+
+        $this->addField($runnerVoidField);
+
+        $skippedTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::WHITE . Colors::BOLD);
+        $skippedTestMethodPrompt = clone $secondLevelPrompt;
+        $skippedTestMethodPrompt->setColorizer($skippedTestColorizer);
+
+        $runnerSkippedField = new runner\tests\skipped\cli();
+        $runnerSkippedField
+            ->setTitlePrompt($firstLevelPrompt)
+            ->setTitleColorizer($skippedTestColorizer)
+            ->setMethodPrompt($skippedTestMethodPrompt)
+        ;
+
+        $this->addField($runnerSkippedField);
+
+        $testRunField = new test\run\cli();
+        $testRunField
+            ->setPrompt($firstLevelPrompt)
+            ->setColorizer($defaultColorizer)
+        ;
+
+        $this->addField($testRunField);
+
+        $this->addField(new test\event\cli());
+
+        $testDurationField = new test\duration\cli();
+        $testDurationField
+            ->setPrompt($secondLevelPrompt)
+        ;
+
+        $this->addField($testDurationField);
+
+        $testMemoryField = new test\memory\cli();
+        $testMemoryField
+            ->SetPrompt($secondLevelPrompt)
+        ;
+
+        $this->addField($testMemoryField);
+    }
+
+    public function hideClassesCoverageDetails()
+    {
+        $this->runnerTestsCoverageField->hideClassesCoverageDetails();
+
+        return $this;
+    }
+
+    public function hideMethodsCoverageDetails()
+    {
+        $this->runnerTestsCoverageField->hideMethodsCoverageDetails();
+
+        return $this;
+    }
+}

--- a/Report/Cli/Cli.php
+++ b/Report/Cli/Cli.php
@@ -48,10 +48,8 @@ class Cli extends atoum\reports\realtime
     {
         parent::__construct();
 
-        $this->addField(new Fields\Logo());
-
-        $defaultColorizer = new atoum\cli\colorizer(Colors::FG . Colors::WHITE);
-        $defaultPromptColorizer = new atoum\cli\colorizer(Colors::FG . Colors::RED);
+        $defaultColorizer = new Colorizer('foreground(' . Colors::BLACK . ') bold');
+        $defaultPromptColorizer = new Colorizer('foreground(' . Colors::GRAY . ')');
 
         $firstLevelPrompt  = new atoum\cli\prompt('> ', $defaultPromptColorizer);
         $secondLevelPrompt = new atoum\cli\prompt('=> ', $defaultPromptColorizer);
@@ -126,13 +124,13 @@ class Cli extends atoum\reports\realtime
 
         $runnerResultField = new Fields\Result();
         $runnerResultField
-            ->setSuccessColorizer(new atoum\cli\colorizer(Colors::BG . Colors::GREEN, Colors::FG . Colors::BLACK . Colors::BOLD))
-            ->setFailureColorizer(new atoum\cli\colorizer(Colors::BG . Colors::RED, Colors::FG . Colors::BLACK . Colors::BOLD))
+            ->setSuccessColorizer(new Colorizer('background(' . Colors::GREEN . ') foreground(' . Colors::WHITE . ') bold'))
+            ->setFailureColorizer(new Colorizer('background(' . Colors::RED . ') foreground(' . Colors::WHITE . ') bold'))
         ;
 
         $this->addField($runnerResultField);
 
-        $failureColorizer = new atoum\cli\colorizer(Colors::FG . Colors::RED . Colors::BOLD);
+        $failureColorizer = new Colorizer('foreground(' . Colors::RED . ')');
         $failureTitlePrompt = clone $firstLevelPrompt;
         $failureTitlePrompt->setColorizer($failureColorizer);
         $failurePrompt = clone $secondLevelPrompt;
@@ -156,7 +154,7 @@ class Cli extends atoum\reports\realtime
 
         $this->addField($runnerOutputsField);
 
-        $errorColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::YELLOW . Colors::BOLD);
+        $errorColorizer = new Colorizer('foreground(' . Colors::YELLOW . ') bold');
         $errorTitlePrompt = clone $firstLevelPrompt;
         $errorTitlePrompt->setColorizer($errorColorizer);
         $errorMethodPrompt = clone $secondLevelPrompt;
@@ -174,7 +172,7 @@ class Cli extends atoum\reports\realtime
 
         $this->addField($runnerErrorsField);
 
-        $exceptionColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::VIOLET . Colors::BOLD);
+        $exceptionColorizer = new Colorizer('foreground(' . Colors::VIOLET . ') bold');
         $exceptionTitlePrompt = clone $firstLevelPrompt;
         $exceptionTitlePrompt->setColorizer($exceptionColorizer);
         $exceptionMethodPrompt = clone $secondLevelPrompt;
@@ -192,7 +190,7 @@ class Cli extends atoum\reports\realtime
 
         $this->addField($runnerExceptionsField);
 
-        $uncompletedTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::WHITE . Colors::BOLD);
+        $uncompletedTestColorizer = new Colorizer('foreground(' . Colors::GRAY . ') bold');
         $uncompletedTestTitlePrompt = clone $firstLevelPrompt;
         $uncompletedTestTitlePrompt->setColorizer($uncompletedTestColorizer);
         $uncompletedTestMethodPrompt = clone $secondLevelPrompt;
@@ -210,7 +208,7 @@ class Cli extends atoum\reports\realtime
 
         $this->addField($runnerUncompletedField);
 
-        $voidTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::BLUE . Colors::BOLD);
+        $voidTestColorizer = new Colorizer('foreground(' . Colors::BLUE . ') bold');
         $voidTestTitlePrompt = clone $firstLevelPrompt;
         $voidTestTitlePrompt->setColorizer($voidTestColorizer);
         $voidTestMethodPrompt = clone $secondLevelPrompt;
@@ -225,7 +223,7 @@ class Cli extends atoum\reports\realtime
 
         $this->addField($runnerVoidField);
 
-        $skippedTestColorizer    = new atoum\cli\colorizer(Colors::FG . Colors::WHITE . Colors::BOLD);
+        $skippedTestColorizer = new Colorizer('foreground(' . Colors::GRAY . ') bold');
         $skippedTestMethodPrompt = clone $secondLevelPrompt;
         $skippedTestMethodPrompt->setColorizer($skippedTestColorizer);
 

--- a/Report/Cli/Colorizer.php
+++ b/Report/Cli/Colorizer.php
@@ -34,21 +34,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Hoa\Test\Report\Cli\Fields;
+namespace Hoa\Test\Report\Cli;
 
-use Hoa\Test\Report\Cli\Colors;
-use atoum\report\fields;
+use atoum;
 
-class Logo extends fields\runner\atoum\cli
+class Colorizer extends atoum\cli\colorizer
 {
-    public function __toString()
+    private $style;
+
+    public function __construct($style)
     {
-        return Colors::PREFIX . Colors::FG . Colors::VIOLET . Colors::BOLD . Colors::SUFFIX .
-        '        _   _' . "\n" .
-        '       | | | | ___   __ _' . "\n" .
-        '       | |_| |/ _ \ / _` |' . "\n" .
-        '       |  _  | (_) | (_| |' . "\n" .
-        '       |_| |_|\___/ \__,_|' . "\n" .
-        Colors::PREFIX . Colors::RESET . Colors::SUFFIX  . PHP_EOL;
+        $this->style = $style;
+    }
+
+    public function colorize($message)
+    {
+        return \Hoa\Console\Chrome\Text::colorize($message, $this->style);
     }
 }

--- a/Report/Cli/Colors.php
+++ b/Report/Cli/Colors.php
@@ -38,22 +38,12 @@ namespace Hoa\Test\Report\Cli;
 
 final class Colors
 {
-    const PREFIX = "\033[";
-    const SUFFIX = 'm';
-
-    const FG = '38;';
-    const BG = '48;';
-
-    const BOLD = ';1';
-    const UNDERLINE = ';4';
-
-    const RESET  = '0';
-    const WHITE  = '5;255'; //#FFFFFF
-    const BLACK  = '5;236'; //#341d44
-    const VIOLET = '5;161'; //#D62988
-    const GREEN  = '5;71'; //#6CBE6C
-    const RED    = '5;131'; //#BD7573
-    const YELLOW = '5;185'; //#E0D95C
-    const BLUE   = '5;32'; //#E0D95C
-    const ORANGE = '5;136'; //#B27E28
+    const WHITE  = '#FFFFFF';
+    const GRAY   = '#CCCCCC';
+    const BLACK  = '#341d44';
+    const VIOLET = '#D62988';
+    const GREEN  = '#6CBE6C';
+    const RED    = '#BD7573';
+    const YELLOW = '#E0D95C';
+    const BLUE   = '#E0D95C';
 }

--- a/Report/Cli/Colors.php
+++ b/Report/Cli/Colors.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli;
+
+final class Colors
+{
+    const PREFIX = "\033[";
+    const SUFFIX = 'm';
+
+    const FG = '38;';
+    const BG = '48;';
+
+    const BOLD = ';1';
+    const UNDERLINE = ';4';
+
+    const RESET  = '0';
+    const WHITE  = '5;255'; //#FFFFFF
+    const BLACK  = '5;236'; //#341d44
+    const VIOLET = '5;161'; //#D62988
+    const GREEN  = '5;71'; //#6CBE6C
+    const RED    = '5;131'; //#BD7573
+    const YELLOW = '5;185'; //#E0D95C
+    const BLUE   = '5;32'; //#E0D95C
+    const ORANGE = '5;136'; //#B27E28
+}

--- a/Report/Cli/Fields/Logo.php
+++ b/Report/Cli/Fields/Logo.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli\Fields;
+
+use Hoa\Test\Report\Cli\Colors;
+use atoum\report\fields;
+
+class Logo extends fields\runner\atoum\cli
+{
+    public function __toString()
+    {
+        return Colors::PREFIX . Colors::FG . Colors::VIOLET . Colors::BOLD . Colors::SUFFIX .
+        '        _   _' . "\n" .
+        '       | | | | ___   __ _' . "\n" .
+        '       | |_| |/ _ \ / _` |' . "\n" .
+        '       |  _  | (_) | (_| |' . "\n" .
+        '       |_| |_|\___/ \__,_|' . "\n" .
+        Colors::PREFIX . Colors::RESET . Colors::SUFFIX  . PHP_EOL;
+    }
+}

--- a/Report/Cli/Fields/Result.php
+++ b/Report/Cli/Fields/Result.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli\Fields;
+
+use atoum\report\fields;
+
+class Result extends fields\runner\result\cli
+{
+    public function __toString()
+    {
+        $string = $this->prompt;
+
+        if ($this->testNumber === null) {
+            $string .= $this->locale->_('No test running.');
+        } elseif ($this->success) {
+            $string .= $this->successColorizer->colorize(
+                sprintf(
+                    $this->locale->_('Success (%s, %s, %s, %s, %s)!'),
+                    sprintf($this->locale->__('%s test suite', '%s test suites', $this->testNumber), $this->testNumber),
+                    sprintf($this->locale->__('%s/%s test case', '%s/%s test cases', $this->testMethodNumber), $this->testMethodNumber - $this->voidMethodNumber - $this->skippedMethodNumber, $this->testMethodNumber),
+                    sprintf($this->locale->__('%s void test case', '%s void test cases', $this->voidMethodNumber), $this->voidMethodNumber),
+                    sprintf($this->locale->__('%s skipped test case', '%s skipped test cases', $this->skippedMethodNumber), $this->skippedMethodNumber),
+                    sprintf($this->locale->__('%s assertion', '%s assertions', $this->assertionNumber), $this->assertionNumber)
+                )
+            )
+            ;
+        } else {
+            $string .= $this->failureColorizer->colorize(
+                sprintf(
+                    $this->locale->_('Failure (%s, %s, %s, %s, %s, %s, %s, %s)!'),
+                    sprintf($this->locale->__('%s test suite', '%s test suites', $this->testNumber), $this->testNumber),
+                    sprintf($this->locale->__('%s/%s test case', '%s/%s test cases', $this->testMethodNumber), $this->testMethodNumber - $this->voidMethodNumber - $this->skippedMethodNumber - $this->uncompletedMethodNumber, $this->testMethodNumber),
+                    sprintf($this->locale->__('%s void test case', '%s void test cases', $this->voidMethodNumber), $this->voidMethodNumber),
+                    sprintf($this->locale->__('%s skipped test case', '%s skipped test cases', $this->skippedMethodNumber), $this->skippedMethodNumber),
+                    sprintf($this->locale->__('%s uncompleted test case', '%s uncompleted test case', $this->uncompletedMethodNumber), $this->uncompletedMethodNumber),
+                    sprintf($this->locale->__('%s failure', '%s failures', $this->failNumber), $this->failNumber),
+                    sprintf($this->locale->__('%s error', '%s errors', $this->errorNumber), $this->errorNumber),
+                    sprintf($this->locale->__('%s exception', '%s exceptions', $this->exceptionNumber), $this->exceptionNumber)
+                )
+            )
+            ;
+        }
+
+        return $string . PHP_EOL;
+    }
+}

--- a/Report/Cli/Fields/Uncompleted.php
+++ b/Report/Cli/Fields/Uncompleted.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli\Fields;
+
+use atoum\report\fields;
+
+class Uncompleted extends fields\runner\tests\uncompleted\cli
+{
+    public function __toString()
+    {
+        $string = '';
+
+        if ($this->runner !== null) {
+            $uncompletedMethods = $this->runner->getScore()->getUncompletedMethods();
+
+            $sizeOfUncompletedMethod = sizeof($uncompletedMethods);
+
+            if ($sizeOfUncompletedMethod > 0) {
+                $string .=
+                    $this->titlePrompt .
+                    sprintf(
+                        $this->locale->_('%s:'),
+                        $this->titleColorizer->colorize(sprintf($this->locale->__('There is %d uncompleted test case', 'There are %d uncompleted test cases', $sizeOfUncompletedMethod), $sizeOfUncompletedMethod))
+                    ) .
+                    PHP_EOL
+                ;
+
+                foreach ($uncompletedMethods as $uncompletedMethod) {
+                    $string .=
+                        $this->methodPrompt .
+                        sprintf(
+                            $this->locale->_('%s:'),
+                            $this->methodColorizer->colorize(sprintf('%s::%s() with exit code %d', $uncompletedMethod['class'], $uncompletedMethod['method'], $uncompletedMethod['exitCode']))
+                        ) .
+                        PHP_EOL
+                    ;
+
+                    $lines = explode(PHP_EOL, trim($uncompletedMethod['output']));
+
+                    $string .= $this->outputPrompt . 'output(' . strlen($uncompletedMethod['output']) . ') "' . array_shift($lines);
+
+                    foreach ($lines as $line) {
+                        $string .= PHP_EOL . $this->outputPrompt . $line;
+                    }
+
+                    $string .= '"' . PHP_EOL;
+                }
+            }
+        }
+
+        return $string;
+    }
+}

--- a/Report/Cli/Fields/Void.php
+++ b/Report/Cli/Fields/Void.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Test\Report\Cli\Fields;
+
+use atoum\report\fields;
+
+class Void extends fields\runner\tests\void\cli
+{
+    public function __toString()
+    {
+        $string = '';
+
+        if ($this->runner !== null) {
+            $voidMethods = $this->runner->getScore()->getVoidMethods();
+
+            $sizeOfVoidMethod = sizeof($voidMethods);
+
+            if ($sizeOfVoidMethod > 0) {
+                $string .=
+                    $this->titlePrompt .
+                    sprintf(
+                        $this->locale->_('%s:'),
+                        $this->titleColorizer->colorize(
+                            sprintf(
+                                $this->locale->__(
+                                    'There is %d void test case',
+                                    'There are %d void test cases',
+                                    $sizeOfVoidMethod
+                                ),
+                                $sizeOfVoidMethod
+                            )
+                        )
+                    ) .
+                    PHP_EOL;
+
+                foreach ($voidMethods as $voidMethod) {
+                    $string .= $this->methodPrompt .
+                        $this->methodColorizer->colorize(sprintf('%s::%s()', $voidMethod['class'], $voidMethod['method'])) .
+                        PHP_EOL;
+                }
+            }
+        }
+
+        return $string;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "hoa/devtools"              : "~1.0",
         "hoa/file"                  : "~1.0",
         "hoa/protocol"              : "~1.0",
-        "hoa/ustring"               : "~4.0"
+        "hoa/ustring"               : "~4.0",
+        "hoa/console"               : "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See #40 for the disucssion. The goal is to provide a custom CLI report for atoum which uses a more appropriate wording in the context of Hoa's tests.

So here it is :)

Basically, this report is the same as the default atoum CLI report but some things changed:

* the colors are more consistent with Hoa's color
* Hoa's logo is displayed at the top of the report
* Wording has been changed (classes => test suites, methods => test cases, ...)

A screenshot is worth a thousand words:

* On `hoa/json`
![capture d ecran 2015-09-23 a 11 54 10](https://cloud.githubusercontent.com/assets/327237/10042162/f68d0526-61e9-11e5-8e50-8237b3c7dbac.png)

* On a custom test to show actual failures:
![atoum_hoa_full](https://cloud.githubusercontent.com/assets/327237/10042167/0278e634-61ea-11e5-8bc2-78ccafe964ef.png)

Edit from @Hywan: Fix #40.