### PR TITLE
VFS: Force `type=file`. If absent, no resolution

### DIFF
--- a/Protocol/Vfs.php
+++ b/Protocol/Vfs.php
@@ -81,18 +81,23 @@ class Vfs extends Core\Protocol
         $components = parse_url($queue);
         $path       = &$components['path'];
 
-        if (isset($components['query'])) {
-            parse_str($components['query'], $queries);
-        } else {
-            $queries = ['type' => 'file'];
+        if (isset($this->_streams[$path])) {
+            return $this->_streams[$path];
         }
 
-        if (isset($queries['type']) &&
-            'directory' === $queries['type']) {
+        if (!isset($components['query'])) {
+            return 'atoum:/' . Core\Protocol::NO_RESOLUTION;
+        }
+
+        parse_str($components['query'], $queries);
+
+        if ('directory' === $queries['type']) {
             $file              = atoum\mock\streams\fs\directory::get($path);
             $file->dir_opendir = true;
-        } else {
+        } elseif ('file' === $queries['type']) {
             $file = atoum\mock\streams\fs\file::get($path);
+        } else {
+            return 'atoum:/' . Core\Protocol::NO_RESOLUTION;
         }
 
         $parentDirectory = dirname($path);


### PR DESCRIPTION
Previously, if no `type` query was specify, we considered `type=file` by default. Unfortunately, this was therefore impossible to check whether a file exists or not because it was always created.

Now, we use `?type=xxx` to force the creation of a file (`file` or `directory`). If absent, we check whether it exists or not. This is more consistent.