### PR TITLE
Update `test:run` default behaviour to use `Test` directory by default

### DIFF
--- a/Bin/Run.php
+++ b/Bin/Run.php
@@ -274,6 +274,10 @@ class Run extends Console\Dispatcher\Kit
             $command .= ' --php ' . $php;
         }
 
+        if (empty($directories) && empty($files) && empty($namespaces) && is_dir('Test')) {
+            $directories[] = 'Test';
+        }
+
         if (!empty($directories)) {
             $command .= ' --directories ' . implode(' ', $directories);
         } elseif (!empty($files)) {


### PR DESCRIPTION
For the moment when you run the command `test:run` the usage help is displayed. With this PR, the `Test` directory is used by default if nothing is given as command parameter :

```shell
vendor/bin/hoa test:run
```