### PR TITLE
WIP: Replace reserved keyword "Void" to "Nil"

### DIFF
--- a/Report/Cli/Cli.php
+++ b/Report/Cli/Cli.php
@@ -201,7 +201,7 @@ class Cli extends atoum\reports\realtime
         $voidTestMethodPrompt = clone $secondLevelPrompt;
         $voidTestMethodPrompt->setColorizer($voidTestColorizer);
 
-        $runnerVoidField = new Fields\Void();
+        $runnerVoidField = new Fields\Nil();
         $runnerVoidField
             ->setTitlePrompt($voidTestTitlePrompt)
             ->setTitleColorizer($voidTestColorizer)

--- a/Report/Cli/Fields/Nil.php
+++ b/Report/Cli/Fields/Nil.php
@@ -38,7 +38,7 @@ namespace Hoa\Test\Report\Cli\Fields;
 
 use atoum\report\fields;
 
-class Void extends fields\runner\tests\void\cli
+class Nil extends fields\runner\tests\blank\cli
 {
     public function __toString()
     {


### PR DESCRIPTION
Address https://github.com/hoaproject/Consistency/issues/10.
Address https://github.com/hoaproject/Test/issues/70.

`void` for PHP-7.1 is now a reserved keyword[1]. This patch replace the
class `Fields\Void` to the new class `Fields\Nil`.

[1] https://github.com/php/php-src/blob/php-7.1.0alpha2/UPGRADING
