### PR TITLE
Bin: Do not set `HOA_PRELUDE_FILES` if empty

### DIFF
--- a/Bin/Run.php
+++ b/Bin/Run.php
@@ -327,7 +327,10 @@ class Run extends Console\Dispatcher\Kit
 
         $_server                      = $_SERVER;
         $_server['HOA_PREVIOUS_CWD']  = getcwd();
-        $_server['HOA_PRELUDE_FILES'] = implode("\n", $preludeFiles);
+
+        if (!empty($preludeFiles)) {
+            $_server['HOA_PRELUDE_FILES'] = implode("\n", $preludeFiles);
+        }
 
         $processus = new Processus(
             $command,


### PR DESCRIPTION
Fix #75.

Having an empty `HOA_PRELUDE_FILES` environment variable is filtered by PHP, but not by HHVM. So `.autoloader.atoum.php` will try to load a file named `''`, which is incorrect.