### PR TITLE
Bin: Simplify path to atoum

### DIFF
--- a/Bin/Run.php
+++ b/Bin/Run.php
@@ -268,18 +268,14 @@ class Run extends Console\Dispatcher\Kit
         if (WITH_COMPOSER) {
             // From the `vendor/hoa/test/Bin/` directory.
             $atoum =
-                __DIR__ . DS .
-                '..' . DS .
-                '..' . DS .
-                '..' . DS .
+                dirname(dirname(dirname(__DIR__))) . DS .
                 'bin' . DS .
                 'atoum';
 
             if (false === file_exists($atoum)) {
                 // From `Bin/` directory.
                 $atoum =
-                    __DIR__ . DS .
-                    '..' . DS .
+                    dirname(__DIR__) . DS .
                     'vendor' . DS .
                     'bin' . DS .
                     'atoum';


### PR DESCRIPTION
Related to https://github.com/hoaproject/Test/issues/83.

Avoid having `..` pieces in the path. Directly compute an absolute path.